### PR TITLE
Fix FreeSASA usage in surface analysis

### DIFF
--- a/ai_peptide_suggester.py
+++ b/ai_peptide_suggester.py
@@ -8,6 +8,14 @@ def suggest_with_openai(sequence: str, residues: List[Dict], surface_df: Optiona
     # Build enhanced context with surface information
     surface_context = ""
     if surface_df is not None and not surface_df.empty:
+        exposed = (
+            surface_df.to_string(index=False)
+            if len(surface_df) <= 20
+            else surface_df.head(20).to_string(index=False)
+        )
+        if len(surface_df) > 20:
+            exposed += f"\n... and {len(surface_df) - 20} more residues"
+
         surface_context = f"""
 SURFACE ANALYSIS DATA:
 - Total surface residues: {len(surface_df)}
@@ -16,7 +24,7 @@ SURFACE ANALYSIS DATA:
 - Polar surface residues: {len(surface_df[surface_df['Property'] == 'Polar/Other'])}
 
 Surface-exposed residues (SASA > 25 Å²):
-{surface_df.to_string(index=False) if len(surface_df) <= 20 else surface_df.head(20).to_string(index=False) + f"\n... and {len(surface_df) - 20} more residues"}
+{exposed}
 """
     
     # Enhanced prompt with surface analysis

--- a/surface_analysis.py
+++ b/surface_analysis.py
@@ -8,7 +8,10 @@ except ModuleNotFoundError as exc:
 import pandas as pd
 from typing import Dict, Any, List, Tuple
 
-def analyze_surface_residues(pdb_content: str, selected_chain: str = 'A') -> Tuple[pd.DataFrame, List[str]]:
+
+def analyze_surface_residues(
+    pdb_content: str, selected_chain: str = "A"
+) -> Tuple[pd.DataFrame, List[str]]:
     """
     Analyze surface residues using FreeSASA to calculate solvent-accessible surface area (SASA).
     Only standard amino acids are included.
@@ -16,16 +19,37 @@ def analyze_surface_residues(pdb_content: str, selected_chain: str = 'A') -> Tup
     and a list of debug info strings for SASA values.
     """
     import tempfile, os
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.pdb', delete=False) as temp_file:
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".pdb", delete=False
+    ) as temp_file:
         temp_file.write(pdb_content)
         temp_file_path = temp_file.name
 
     standard_residues = {
-        'ALA', 'ARG', 'ASN', 'ASP', 'CYS', 'GLN', 'GLU', 'GLY', 'HIS', 'ILE',
-        'LEU', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL'
+        "ALA",
+        "ARG",
+        "ASN",
+        "ASP",
+        "CYS",
+        "GLN",
+        "GLU",
+        "GLY",
+        "HIS",
+        "ILE",
+        "LEU",
+        "LYS",
+        "MET",
+        "PHE",
+        "PRO",
+        "SER",
+        "THR",
+        "TRP",
+        "TYR",
+        "VAL",
     }
-    HYDROPHOBIC = {'A', 'V', 'L', 'I', 'M', 'F', 'Y', 'W'}
-    CHARGED = {'D', 'E', 'K', 'R', 'H'}
+    HYDROPHOBIC = {"A", "V", "L", "I", "M", "F", "Y", "W"}
+    CHARGED = {"D", "E", "K", "R", "H"}
 
     def classify_residue(residue_name: str) -> str:
         if residue_name[0] in HYDROPHOBIC:
@@ -45,74 +69,6 @@ def analyze_surface_residues(pdb_content: str, selected_chain: str = 'A') -> Tup
         if not chain_residues:
             debug_info.append(f"chain {selected_chain} not found")
         for resnum, area in chain_residues.items():
-                try:
-                    resnum_int = int(resnum)
-                except ValueError:
-                    continue
-                resname = area.residueType
-                sasa = area.total
-                if resname not in standard_residues:
-                    continue
-                if sasa > 0.0:
-                    property_type = classify_residue(resname)
-                    residues_data.append({
-                        'Residue Name': resname,
-                        'Residue Number': resnum_int,
-                        'Chain': selected_chain,
-                        'SASA': float(sasa),
-                        'Property': property_type
-                    })
-        df = pd.DataFrame(residues_data)
-        if not df.empty:
-            df = df.sort_values('Residue Number')
-        return df, debug_info
-    finally:
-        if os.path.exists(temp_file_path):
-            os.unlink(temp_file_path)
-
-def get_surface_summary(surface_df: pd.DataFrame) -> Dict[str, Any]:
-    """
-    Generate a summary of surface analysis results.
-    
-    Args:
-        surface_df (pd.DataFrame): Surface analysis DataFrame
-    
-    Returns:
-        Dict[str, Any]: Summary statistics
-    """
-    if surface_df.empty:
-        return {
-            'total_surface_residues': 0,
-            'hydrophobic_count': 0,
-            'charged_count': 0,
-            'polar_count': 0,
-            'avg_sasa': 0.0,
-            'max_sasa': 0.0
-        }
-    summary = {
-        'total_surface_residues': len(surface_df),
-        'hydrophobic_count': len(surface_df[surface_df['Property'] == 'Hydrophobic']),
-        'charged_count': len(surface_df[surface_df['Property'] == 'Charged']),
-        'polar_count': len(surface_df[surface_df['Property'] == 'Polar/Other']),
-        'avg_sasa': round(surface_df['SASA'].mean(), 2),
-        'max_sasa': round(surface_df['SASA'].max(), 2)
-    }
-    return summary 
-
-def get_exposed_residues_from_pdb(pdb_filepath: str, selected_chain: str = 'A', sasa_threshold: float = 25.0) -> List[Dict[str, Any]]:
-    """
-    Compute residue-level SASA using FreeSASA and return a list of exposed residues above a threshold.
-    Only standard amino acids are included.
-    """
-    standard_residues = {
-        'ALA', 'ARG', 'ASN', 'ASP', 'CYS', 'GLN', 'GLU', 'GLY', 'HIS', 'ILE',
-        'LEU', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL'
-    }
-    structure = freesasa.Structure(pdb_filepath)
-    result = freesasa.calc(structure)
-    exposed_residues = []
-    chain_residues = result.residueAreas().get(selected_chain, {})
-    for resnum, area in chain_residues.items():
             try:
                 resnum_int = int(resnum)
             except ValueError:
@@ -121,11 +77,109 @@ def get_exposed_residues_from_pdb(pdb_filepath: str, selected_chain: str = 'A', 
             sasa = area.total
             if resname not in standard_residues:
                 continue
-            if sasa > sasa_threshold:
-                exposed_residues.append({
-                    'chain': selected_chain,
-                    'residue_number': resnum_int,
-                    'residue_name': resname,
-                    'sasa': float(sasa)
-                })
-    return exposed_residues 
+            if sasa > 0.0:
+                property_type = classify_residue(resname)
+                residues_data.append(
+                    {
+                        "Residue Name": resname,
+                        "Residue Number": resnum_int,
+                        "Chain": selected_chain,
+                        "SASA": float(sasa),
+                        "Property": property_type,
+                    }
+                )
+        df = pd.DataFrame(residues_data)
+        if not df.empty:
+            df = df.sort_values("Residue Number")
+        return df, debug_info
+    finally:
+        if os.path.exists(temp_file_path):
+            os.unlink(temp_file_path)
+
+
+def get_surface_summary(surface_df: pd.DataFrame) -> Dict[str, Any]:
+    """
+    Generate a summary of surface analysis results.
+
+    Args:
+        surface_df (pd.DataFrame): Surface analysis DataFrame
+
+    Returns:
+        Dict[str, Any]: Summary statistics
+    """
+    if surface_df.empty:
+        return {
+            "total_surface_residues": 0,
+            "hydrophobic_count": 0,
+            "charged_count": 0,
+            "polar_count": 0,
+            "avg_sasa": 0.0,
+            "max_sasa": 0.0,
+        }
+    summary = {
+        "total_surface_residues": len(surface_df),
+        "hydrophobic_count": len(
+            surface_df[surface_df["Property"] == "Hydrophobic"]
+        ),
+        "charged_count": len(surface_df[surface_df["Property"] == "Charged"]),
+        "polar_count": len(
+            surface_df[surface_df["Property"] == "Polar/Other"]
+        ),
+        "avg_sasa": round(surface_df["SASA"].mean(), 2),
+        "max_sasa": round(surface_df["SASA"].max(), 2),
+    }
+    return summary
+
+
+def get_exposed_residues_from_pdb(
+    pdb_filepath: str, selected_chain: str = "A", sasa_threshold: float = 25.0
+) -> List[Dict[str, Any]]:
+    """
+    Compute residue-level SASA using FreeSASA and return a list of exposed residues above a threshold.
+    Only standard amino acids are included.
+    """
+    standard_residues = {
+        "ALA",
+        "ARG",
+        "ASN",
+        "ASP",
+        "CYS",
+        "GLN",
+        "GLU",
+        "GLY",
+        "HIS",
+        "ILE",
+        "LEU",
+        "LYS",
+        "MET",
+        "PHE",
+        "PRO",
+        "SER",
+        "THR",
+        "TRP",
+        "TYR",
+        "VAL",
+    }
+    structure = freesasa.Structure(pdb_filepath)
+    result = freesasa.calc(structure)
+    exposed_residues = []
+    chain_residues = result.residueAreas().get(selected_chain, {})
+    for resnum, area in chain_residues.items():
+        try:
+            resnum_int = int(resnum)
+        except ValueError:
+            continue
+        resname = area.residueType
+        sasa = area.total
+        if resname not in standard_residues:
+            continue
+        if sasa > sasa_threshold:
+            exposed_residues.append(
+                {
+                    "chain": selected_chain,
+                    "residue_number": resnum_int,
+                    "residue_name": resname,
+                    "sasa": float(sasa),
+                }
+            )
+    return exposed_residues

--- a/surface_analysis.py
+++ b/surface_analysis.py
@@ -1,4 +1,10 @@
-import freesasa
+try:
+    import freesasa
+except ModuleNotFoundError as exc:
+    raise ImportError(
+        "FreeSASA is required for surface analysis. Install it with `pip install freesasa`."
+    ) from exc
+
 import pandas as pd
 from typing import Dict, Any, List, Tuple
 
@@ -34,30 +40,28 @@ def analyze_surface_residues(pdb_content: str, selected_chain: str = 'A') -> Tup
         structure = freesasa.Structure(temp_file_path)
         result = freesasa.calc(structure)
         residues_data = []
-        for key, sasa in result.residueAreas().items():
-            debug_info.append(f"key={key}, sasa={sasa}")
-        for key, sasa in result.residueAreas().items():
-            if isinstance(key, tuple) and len(key) == 3:
-                chain, resnum, resname = key
+        residue_areas = result.residueAreas()
+        chain_residues = residue_areas.get(selected_chain, {})
+        if not chain_residues:
+            debug_info.append(f"chain {selected_chain} not found")
+        for resnum, area in chain_residues.items():
                 try:
-                    resnum = int(resnum)
+                    resnum_int = int(resnum)
                 except ValueError:
                     continue
-            else:
-                continue
-            if chain != selected_chain:
-                continue
-            if resname not in standard_residues:
-                continue
-            if sasa > 0.0:
-                property_type = classify_residue(resname)
-                residues_data.append({
-                    'Residue Name': resname,
-                    'Residue Number': resnum,
-                    'Chain': chain,
-                    'SASA': float(sasa),
-                    'Property': property_type
-                })
+                resname = area.residueType
+                sasa = area.total
+                if resname not in standard_residues:
+                    continue
+                if sasa > 0.0:
+                    property_type = classify_residue(resname)
+                    residues_data.append({
+                        'Residue Name': resname,
+                        'Residue Number': resnum_int,
+                        'Chain': selected_chain,
+                        'SASA': float(sasa),
+                        'Property': property_type
+                    })
         df = pd.DataFrame(residues_data)
         if not df.empty:
             df = df.sort_values('Residue Number')
@@ -107,24 +111,21 @@ def get_exposed_residues_from_pdb(pdb_filepath: str, selected_chain: str = 'A', 
     structure = freesasa.Structure(pdb_filepath)
     result = freesasa.calc(structure)
     exposed_residues = []
-    for key, sasa in result.residueAreas().items():
-        if isinstance(key, tuple) and len(key) == 3:
-            chain, resnum, resname = key
+    chain_residues = result.residueAreas().get(selected_chain, {})
+    for resnum, area in chain_residues.items():
             try:
-                resnum = int(resnum)
+                resnum_int = int(resnum)
             except ValueError:
                 continue
-        else:
-            continue
-        if chain != selected_chain:
-            continue
-        if resname not in standard_residues:
-            continue
-        if sasa > sasa_threshold:
-            exposed_residues.append({
-                'chain': chain,
-                'residue_number': resnum,
-                'residue_name': resname,
-                'sasa': float(sasa)
-            })
+            resname = area.residueType
+            sasa = area.total
+            if resname not in standard_residues:
+                continue
+            if sasa > sasa_threshold:
+                exposed_residues.append({
+                    'chain': selected_chain,
+                    'residue_number': resnum_int,
+                    'residue_name': resname,
+                    'sasa': float(sasa)
+                })
     return exposed_residues 


### PR DESCRIPTION
## Summary
- raise helpful message if FreeSASA isn't installed
- keep chain-specific residue lookup for SASA metrics

## Testing
- `python - <<'EOF'
import surface_analysis as sa
pdb='''ATOM      1  N   GLY A   1      11.104  13.207  10.000  1.00 20.00           N
ATOM      2  CA  GLY A   1      12.560  13.400  10.000  1.00 20.00           C
ATOM      3  C   GLY A   1      13.062  14.822  10.000  1.00 20.00           C
ATOM      4  O   GLY A   1      12.500  15.824  10.000  1.00 20.00           O
ATOM      5  H   GLY A   1      10.504  12.654  10.000  1.00 20.00           H
END\n'''
df, debug = sa.analyze_surface_residues(pdb, selected_chain='A')
print(df)
print('debug', debug)
open('temp_test.pdb','w').write(pdb)
exposed = sa.get_exposed_residues_from_pdb('temp_test.pdb', selected_chain='A', sasa_threshold=0)
print(exposed)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687a1c0bb6088330bfd73bc93b4b0bfb